### PR TITLE
Update dropwizard and support for H2 databases

### DIFF
--- a/conf.yml
+++ b/conf.yml
@@ -16,7 +16,7 @@ logging:
 message: "hello"
 
 dbConfig:
-    driver: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/dw_el?zeroDateTimeBehavior=convertToNull&amp;useUnicode=true&amp;characterEncoding=UTF-8
-    username: dw_el
-    password: dw_el
+    driver: org.h2.Driver
+    url: jdbc:h2:~/example;DB_CLOSE_DELAY=-1;AUTO_RECONNECT=TRUE;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password: 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <dropwizard.version>0.7.1</dropwizard.version>
+        <dropwizard.version>0.8.1</dropwizard.version>
         <guice.version>3.0</guice.version>
         <eclipselink.version>2.5.2</eclipselink.version>
     </properties>
@@ -45,6 +45,11 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>9.4-1200-jdbc41</version>
+        </dependency>
+		<dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.182</version>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
I think is better to use H2 database for testing and start up. Also I updated dropwizard version.